### PR TITLE
Add .env.example file and update .gitignore to include .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id
+NEXT_PUBLIC_PRIVY_APP_SECRET=your_privy_app_secret
+
+NEXT_PUBLIC_PINATA_API_KEY=your_pinata_api_key
+NEXT_PUBLIC_PINATA_JWT=your_pinata_jwt
+NEXT_PUBLIC_PINATA_GATEWAY=your_pinata_gateway
+NEXT_PUBLIC_PINATA_SECRET=your_pinata_secret
+NEXT_PUBLIC_PINATA_GROUP_ID=your_pinata_group_id

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
+
 
 # vercel
 .vercel


### PR DESCRIPTION
- Created a new .env.example file with environment variable placeholders for Privy and Pinata configurations.
- Updated .gitignore to explicitly include .env files, ensuring sensitive information is not tracked.